### PR TITLE
Updating location list to MS's name change

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -14,7 +14,7 @@ sudo apt-get -y -q install curl
 # Pre-installation
 curl https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
 ## Repository Microsoft SQL Server
-sudo add-apt-repository "$(curl https://packages.microsoft.com/config/ubuntu/16.04/mssql-server.list)"
+sudo add-apt-repository "$(curl https://packages.microsoft.com/config/ubuntu/16.04/mssql-server-2017.list)"
 ## Repository SQL Server command-line tools
 sudo add-apt-repository "$(curl https://packages.microsoft.com/config/ubuntu/16.04/prod.list)"
 sudo apt-get -y -q update


### PR DESCRIPTION
mssql-server.list no longer exists:
https://packages.microsoft.com/config/ubuntu/16.04/

Different lists are described here:
https://docs.microsoft.com/en-us/sql/linux/sql-server-linux-change-repo

I chose the one that is stable/updated